### PR TITLE
feat: allow dry runs to generate output without actually editing a release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -68,6 +68,11 @@ inputs:
       A boolean indicating whether the releaser mode is disabled.
     required: false
     default: ''
+  dry-release:
+    description: |
+      A boolean indicating whether the action should run in dry mode. If true, the action will not create or update a release.
+    required: false
+    default: ''
   disable-autolabeler:
     description: |
       A boolean indicating whether the autolabeler mode is disabled.

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -53,6 +53,11 @@ inputs:
       A boolean indicating whether the releaser mode is disabled.
     required: false
     default: ''
+  dry-release:
+    description: |
+      A boolean indicating whether the action should run in dry mode. If true, the action will not create or update a release.
+    required: false
+    default: ''
   disable-autolabeler:
     description: |
       A boolean indicating whether the autolabeler mode is disabled.


### PR DESCRIPTION
mirror of https://github.com/release-drafter/release-drafter/pull/1437